### PR TITLE
Fix example file

### DIFF
--- a/resources/jobby.php
+++ b/resources/jobby.php
@@ -8,7 +8,7 @@
 
 require(__DIR__ . '/vendor/autoload.php');
 
-$jobby = new Jobby();
+$jobby = new \Jobby\Jobby();
 
 $jobby->add('CommandExample', array(
     'command' => 'ls',


### PR DESCRIPTION
Call to Jobby in example file without namespace causes error

```
lwh@lwh-notebook:~$ php jobby.php 
PHP Fatal error:  Class 'Jobby' not found in /home/lwh/jobby.php on line 11
PHP Stack trace:
PHP   1. {main}() /home/lwh/jobby.php:0
```
