### PR TITLE
Fix vendor autoload issue

### DIFF
--- a/src/Jobby/BackgroundJob.php
+++ b/src/Jobby/BackgroundJob.php
@@ -266,7 +266,7 @@ if (!debug_backtrace()) {
     if (file_exists('vendor/autoload.php')) {
         require('vendor/autoload.php');
     } else {
-        require(dirname(dirname(__DIR__)) . '/vendor/autoload.php');
+        require(dirname(dirname(dirname(dirname(dirname(__DIR__))))) . '/vendor/autoload.php');
     }
 
     spl_autoload_register(function ($class) {


### PR DESCRIPTION
Looks like Jobby is looking for the vendor autoload.php script inside it's own directory which doesn't exist as it should be in the root vendor directory.
