### PR TITLE
Mail transport support for Swiftmailer

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Option         | Default                             | Required | Description
 ===============+=====================================+==========+============
                |                                     |          |
 recipients     | null                                | No       | Comma-separated string of email addresses
-mailer         | sendmail                            | No       | Email method: sendmail or smtp
+mailer         | sendmail                            | No       | Email method: sendmail or smtp or mail
 smtpHost       | null                                | No       | SMTP host, if `mailer` is smtp
 smtpPort       | 25                                  | No       | SMTP port, if `mailer` is smtp
 smtpUsername   | null                                | No       | SMTP user, if `mailer` is smtp

--- a/src/Jobby/Helper.php
+++ b/src/Jobby/Helper.php
@@ -84,6 +84,8 @@ EOF;
             );
             $transport->setUsername($config['smtpUsername']);
             $transport->setPassword($config['smtpPassword']);
+        } elseif($config['mailer'] == 'mail'){
+            $transport = \Swift_MailTransport::newInstance();
         } else {
             $transport = \Swift_SendmailTransport::newInstance();
         }


### PR DESCRIPTION
Found that in some cases Sendmail method in Swiftmailer doesn't work but native Mail transport still does. Jobby could support this method as quick helper for that kind of situations.