### PR TITLE
Allow datetime inside schedule field

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ enabled        | true                                | No       | Run this job a
 haltDir        | null                                | No       | A job will not run if this directory contains a file bearing the job's name
 debug          | false                               | No       | Send `jobby` internal messages to 'debug.log'
 command        | none                                | Yes      | The job to run (either a shell command or anonymous PHP function)
-schedule       | none                                | Yes      | Crontab schedule format (`man -s 5 crontab`)
+schedule       | none                                | Yes      | Crontab schedule format (`man -s 5 crontab`) or Datetime format
 </pre>
 
 ### Example `jobby.php` File ###
@@ -79,8 +79,9 @@ $jobby->add('CommandExample', array(
     // Commands are either shell commands or anonymous functions
     'command' => 'ls',
 
-    // Ordinary crontab schedule format is supported. This schedule runs every
-    // hour
+    // Ordinary crontab schedule format is supported.
+    // This schedule runs every hour.
+    // You could also insert Datetime string.
     'schedule' => '0 * * * *',
 
     // Stdout and stderr is sent to the specified file

--- a/src/Jobby/BackgroundJob.php
+++ b/src/Jobby/BackgroundJob.php
@@ -191,6 +191,11 @@ class BackgroundJob
             }
         }
 
+        $schedule = \DateTime::createFromFormat('Y-m-d H:i:s', $this->config['schedule']);
+        if($schedule!==false){
+            return $schedule->getTimeStamp() == (new \DateTime)->getTimeStamp();
+        }
+
         $cron = CronExpression::factory($this->config['schedule']);
         if (!$cron->isDue()) {
             return false;

--- a/src/Jobby/BackgroundJob.php
+++ b/src/Jobby/BackgroundJob.php
@@ -193,7 +193,7 @@ class BackgroundJob
 
         $schedule = \DateTime::createFromFormat('Y-m-d H:i:s', $this->config['schedule']);
         if($schedule!==false){
-            return $schedule->getTimeStamp() == (new \DateTime)->getTimeStamp();
+            return $schedule->getTimeStamp() == (strtotime(date('Y-m-d H:i')));
         }
 
         $cron = CronExpression::factory($this->config['schedule']);


### PR DESCRIPTION
This module is so useful, but in my experience, I need it to run some jobs on exact time without cron scheduler.

The comparing algorithm use the same algorithm as the `cron-expression` module. I don't make modification on that module 'cause I think it isn't as useful as modification in this module.

In my opinion this is better if you store schedule in other form, such as MySQL database, or MongoDB documents. You don't need to remove jobs from queue like other queue-based scheduler. You just update the saved scheduler form, then when the time is met, jobs would execute.

Thanks.