### PR TITLE
Support for spaces in $logfile

### DIFF
--- a/src/Jobby/BackgroundJob.php
+++ b/src/Jobby/BackgroundJob.php
@@ -274,7 +274,7 @@ class BackgroundJob
         // Start execution. Run in foreground (will block).
         $command = $this->config['command'];
         $logfile = $this->getLogfile() ?: '/dev/null';
-        exec("$useSudo $command 1>> $logfile 2>&1", $dummy, $retval);
+        exec("$useSudo $command 1>> \"$logfile\" 2>&1", $dummy, $retval);
 
         if ($retval !== 0) {
             throw new Exception("Job exited with status '$retval'.");


### PR DESCRIPTION
Exec fails if there is a space in the path of the logfile without this fix.

(i'm using the script on a Windows 2008 RC 2 server and this is the only bug found so far, great script!)