### PR TITLE
Support for phar-based installations

### DIFF
--- a/src/BackgroundJob.php
+++ b/src/BackgroundJob.php
@@ -289,7 +289,7 @@ class BackgroundJob
 // @see: http://stackoverflow.com/questions/2413991/php-equivalent-of-pythons-name-main
 // @codeCoverageIgnoreStart
 $trace = debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS, 1);
-if (!empty($trace)) {
+if (!empty($trace) and !defined('JOBBY_RUN_JOB')) {
     return;
 }
 

--- a/src/Jobby.php
+++ b/src/Jobby.php
@@ -181,7 +181,7 @@ class Jobby
         }
 
         if (strpos(__DIR__, 'phar://') === 0) {
-            return sprintf(' -r \'define("JOBBY_RUN_JOB",1);include("%s");\' "$s" "$s"', $this->script, $job, http_build_query($config));
+            return sprintf(' -r \'define("JOBBY_RUN_JOB",1);include("%s");\' "%s" "%s"', $this->script, $job, http_build_query($config));
         }
         return sprintf('"%s" "%s" "%s"', $this->script, $job, http_build_query($config));
     }

--- a/src/Jobby.php
+++ b/src/Jobby.php
@@ -180,6 +180,9 @@ class Jobby
             ;
         }
 
+        if (strpos(__DIR__, 'phar://') === 0) {
+            return sprintf(' -r \'define("JOBBY_RUN_JOB",1);include("%s");\' "$s" "$s"', $this->script, $job, http_build_query($config));
+        }
         return sprintf('"%s" "%s" "%s"', $this->script, $job, http_build_query($config));
     }
 


### PR DESCRIPTION
When `BackgroundJob.php` is located somewhere within phar archive, then you can not just call it `php phar:///path/to/archive.phar/path/to/BackgroundJob.php`. but you can include it within `php -r`.