### PR TITLE
PHP 8.4 deprecated explicit nullable type

### DIFF
--- a/src/Helper.php
+++ b/src/Helper.php
@@ -26,7 +26,7 @@ class Helper
     /**
      * @param \Swift_Mailer $mailer
      */
-    public function __construct(\Swift_Mailer $mailer = null)
+    public function __construct(?\Swift_Mailer $mailer = null)
     {
         $this->mailer = $mailer;
     }

--- a/src/ScheduleChecker.php
+++ b/src/ScheduleChecker.php
@@ -12,7 +12,7 @@ class ScheduleChecker
      */
     private $now;
 
-    public function __construct(DateTimeImmutable $now = null)
+    public function __construct(?DateTimeImmutable $now = null)
     {
         $this->now = $now instanceof DateTimeImmutable ? $now : new DateTimeImmutable("now");
     }


### PR DESCRIPTION
PHP Deprecated: Jobby\ScheduleChecker::__construct(): Implicitly marking parameter $now as nullable is deprecated, the explicit nullable type must be used instead in vendor/hellogerard/jobby/src/ScheduleChecker.php:15